### PR TITLE
Describe workaround for long checkout times

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,9 +184,7 @@ setup.
            with:
              fetch-depth: 0
          - name: Push
-           run: |
-             git push origin HEAD:master
-             git push origin HEAD:main
+           run: git push origin HEAD:master HEAD:main
    ```
 
 4. Commit and your changes to the local "main" branch.
@@ -218,10 +216,7 @@ This workflow will be triggered when commits are pushed to either the "master"
 or "main" branch. By default, the [checkout action][checkout-action] fetches
 only the latest commit, which is not sufficient for our purpose. Setting the
 `fetch-depth` option to `0` changes it to fetch all the commits and branches.
-It then push the latest commit to both the "master" and "main" branches. In
-practice, one of the two branches (the one that was pushed to) already has the
-commit, so you would expect to see "Everything up-to-date" in one of the two
-pushes.
+It then push the latest commit to both the "master" and "main" branches.
 
 #### Interaction with Branch Protection
 

--- a/README.md
+++ b/README.md
@@ -181,8 +181,6 @@ setup.
        steps:
          - name: Checkout
            uses: actions/checkout@v2
-           with:
-             fetch-depth: 0
          - name: Push
            run: git push origin HEAD:master HEAD:main
    ```
@@ -214,9 +212,10 @@ USD per minute for private repositories, after the free quota is exhausted.
 
 This workflow will be triggered when commits are pushed to either the "master"
 or "main" branch. By default, the [checkout action][checkout-action] fetches
-only the latest commit, which is not sufficient for our purpose. Setting the
-`fetch-depth` option to `0` changes it to fetch all the commits and branches.
-It then push the latest commit to both the "master" and "main" branches.
+only the latest commit, which is more than sufficient for our purpose because
+all of the Git objects needed for the ref update are already in the remote
+repository. It then push the latest commit to both the "master" and "main"
+branches.
 
 #### Interaction with Branch Protection
 
@@ -244,7 +243,6 @@ to push the commits as an administrator:
    - name: Checkout
      uses: actions/checkout@v2
      with:
-       fetch-depth: 0
        token: ${{ secrets.DEPLOY_TOKEN }}
    ```
 
@@ -288,7 +286,6 @@ SSH key to the [checkout action][checkout-action]:
    - name: Checkout
      uses: actions/checkout@v2
      with:
-       fetch-depth: 0
        ssh-key: ${{ secrets.DEPLOY_KEY }}
    ```
 

--- a/README.md
+++ b/README.md
@@ -217,6 +217,21 @@ all of the Git objects needed for the ref update are already in the remote
 repository. It then push the latest commit to both the "master" and "main"
 branches.
 
+#### Avoiding long checkout times
+
+For large repositories, the checkout can take a long time, and waste a lot of
+bandwidth. To avoid this, you can use the "partial clone" feature by replacing
+the steps with this:
+
+```yaml
+      - name: Partial clone
+        run: git clone --bare --depth=1 --single-branch --filter=blob:none ${{ github.event.repository.html_url }} .
+      - name: Configure push token
+        run: git config http.https://github.com/.extraheader "Authorization: Basic $(echo -n x-access-token:${{ github.token }} | base64 --wrap=0)"
+      - name: Push
+        run: git push origin HEAD:master HEAD:main
+```
+
 #### Interaction with Branch Protection
 
 Unfortunately, if you have enabled [branch protection][branch-protection] on

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ This workflow will be triggered when commits are pushed to either the "master"
 or "main" branch. By default, the [checkout action][checkout-action] fetches
 only the latest commit, which is more than sufficient for our purpose because
 all of the Git objects needed for the ref update are already in the remote
-repository. It then push the latest commit to both the "master" and "main"
+repository. It then pushes the latest commit to both the "master" and "main"
 branches.
 
 #### Avoiding long checkout times


### PR DESCRIPTION
When I tried this in https://github.com/dscho/git-sdk-64, the `checkout` step took a whopping five minutes. We don't need the files, and we don't even need to transfer all those Git objects: partial clone is here to save the day.

It looks a bit more complicated than the originally-proposed solution, so I describe this only as an alternative instead of replacing the short-and-sweet solution using `actions/checkout@v2`.