### PR TITLE
Fixes for the partial clone example

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,9 @@ the steps with this:
       - name: Configure Git
       - run: git config --global http.https://github.com/.extraheader "Authorization: Basic $(echo -n x-access-token:${{ github.token }} | base64 --wrap=0)"
       - name: Partial clone
-        run: git clone --bare --depth=1 --single-branch --filter=blob:none ${{ github.event.repository.html_url }} .
+        env:
+          ref: ${{ github.event.ref }}
+        run: git clone --bare --depth=100 --single-branch --branch ${ref#refs/heads/} --filter=blob:none ${{ github.event.repository.html_url }} .
       - name: Push
         run: git push origin HEAD:master HEAD:main
 ```

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ the steps with this:
 
 ```yaml
       - name: Configure Git
-      - run: git config --global http.https://github.com/.extraheader "Authorization: Basic $(echo -n x-access-token:${{ github.token }} | base64 --wrap=0)"
+      - run: git config --global http.https://github.com/.extraheader "Authorization: Basic $(echo -n 'x-access-token:${{ github.token }}' | base64 --wrap=0)"
       - name: Partial clone
         env:
           ref: ${{ github.event.ref }}

--- a/README.md
+++ b/README.md
@@ -224,10 +224,10 @@ bandwidth. To avoid this, you can use the "partial clone" feature by replacing
 the steps with this:
 
 ```yaml
+      - name: Configure Git
+      - run: git config --global http.https://github.com/.extraheader "Authorization: Basic $(echo -n x-access-token:${{ github.token }} | base64 --wrap=0)"
       - name: Partial clone
         run: git clone --bare --depth=1 --single-branch --filter=blob:none ${{ github.event.repository.html_url }} .
-      - name: Configure push token
-        run: git config http.https://github.com/.extraheader "Authorization: Basic $(echo -n x-access-token:${{ github.token }} | base64 --wrap=0)"
       - name: Push
         run: git push origin HEAD:master HEAD:main
 ```


### PR DESCRIPTION
The partial clone example code did not quite work correctly (as I found out the hard way):

- it always cloned the default branch. But if the other branch was pushed, the push to the default branch will fail (because it would try to revert the just-pushed branch).
- it would not work for private repositories, as the clone was performed without using the token.